### PR TITLE
fix update failed

### DIFF
--- a/alibabacloud/ros/pkg/handlers/appconf_handler.go
+++ b/alibabacloud/ros/pkg/handlers/appconf_handler.go
@@ -140,6 +140,11 @@ func (a *AppConfHandler) CreateOrUpdate(ctx *oam.ActionContext, appConf *rosv1al
 				err = application.SetAppStackError(rosContext, err)
 				return err
 			}
+		} else {
+			err = application.SetAppStackIdAndTemplate(rosContext, stack.Id, templateBody)
+			if err != nil {
+				return err
+			}
 		}
 		err = application.SetAppStackProgressing(rosContext)
 	}


### PR DESCRIPTION
After update app conf success, and modify the app conf the last version, then update again will be failed.
It is because after updating success, the controller did not save the new generated template.