### PR TITLE
Change outputs saving and status setting order

### DIFF
--- a/alibabacloud/ros/pkg/handlers/appconf_handler.go
+++ b/alibabacloud/ros/pkg/handlers/appconf_handler.go
@@ -261,13 +261,6 @@ func waitStackDoneAndSaveOutputs(rosContext *ros.Context, stack *ros.Stack, dele
 	if success {
 		logging.Default.Info("Stack runs done")
 
-		if !deleteAppStack {
-			err = application.SetAppStackReady(rosContext)
-			if err != nil {
-				logging.Default.Error(err, "Set app stack ready failed", "AppName", appName)
-			}
-		}
-
 		switch ros.StackStatusType(stack.Status) {
 		case ros.CreateComplete:
 			fallthrough
@@ -275,6 +268,13 @@ func waitStackDoneAndSaveOutputs(rosContext *ros.Context, stack *ros.Stack, dele
 			fallthrough
 		case ros.CheckComplete:
 			application.SaveAppStackOutputs(rosContext, stack)
+		}
+
+		if !deleteAppStack {
+			err = application.SetAppStackReady(rosContext)
+			if err != nil {
+				logging.Default.Error(err, "Set app stack ready failed", "AppName", appName)
+			}
 		}
 	} else {
 		logging.Default.Error(err, "Stack runs failed")


### PR DESCRIPTION
Save outputs first, and then set status ready. Otherwise, for application who monitor the status, may get empty outputs when status is ready.
